### PR TITLE
Fix NHG key with weight overlay flag.

### DIFF
--- a/orchagent/nexthopgroupkey.h
+++ b/orchagent/nexthopgroupkey.h
@@ -33,6 +33,7 @@ public:
 
     NextHopGroupKey(const std::string &nexthops, const std::string &weights)
     {
+        m_overlay_nexthops = false;
         std::vector<std::string> nhv = tokenize(nexthops, NHG_DELIMITER);
         std::vector<std::string> wtv = tokenize(weights, NHG_DELIMITER);
         for (uint32_t i = 0; i < nhv.size(); i++)


### PR DESCRIPTION
Reset m_overlay_nexthops to false for NHG key with weights

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Reset m_overlay_nhs flag to false for NHG with weights
**Why I did it**
Need to explicitly reset the boolean value to false for NHG with weights.
**How I verified it**
Fixing issues that NHG with non overlay NHs not showing up as overlay NHs.
**Details if related**
